### PR TITLE
Add background modeling support to ptychography reconstruction

### DIFF
--- a/adorym/optimizers.py
+++ b/adorym/optimizers.py
@@ -955,6 +955,19 @@ def create_and_initialize_parameter_optimizers(optimizable_params, kwargs):
         opt_args_ls.append(forward_model.get_argument_index('ctf_lg_kappa'))
         opt_ls.append(opt_ctf_lg_kappa)
 
+    if kwargs['background_type'] != 'none' and kwargs['optimize_background']:
+        if kwargs['optimizer_background'] is not None:
+            opt_background = kwargs['optimizer_background']
+            opt_background.name = 'background'
+        else:
+            optimizer_options_background = {'step_size': kwargs['background_learning_rate']}
+            opt_background = AdamOptimizer('background', output_folder=output_folder,
+                                           options_dict=optimizer_options_background, forward_model=forward_model)
+        opt_background.create_param_arrays(optimizable_params['background'].shape, device=device_obj)
+        opt_background.set_index_in_grad_return(len(opt_args_ls))
+        opt_args_ls.append(forward_model.get_argument_index('background'))
+        opt_ls.append(opt_background)
+
     return opt_ls, opt_args_ls
 
 

--- a/demos/2d_ptychography_with_background.py
+++ b/demos/2d_ptychography_with_background.py
@@ -1,0 +1,30 @@
+"""Example reconstruction script that enables background refinement.
+
+The input data file is expected to contain the usual ADORYM datasets,
+plus an additional dataset called ``exchange/background`` that stores the
+measured detector background pattern.  Set ``background_dataset_path`` to
+``None`` if you want to start the background estimate from zeros instead.
+"""
+
+from adorym.ptychography import reconstruct_ptychography
+
+
+def main():
+    reconstruct_ptychography(
+        fname='path/to/ptychography_dataset.h5',
+        obj_size=[512, 512, 1],
+        psize_cm=1.3e-4,
+        free_prop_cm=13.5,
+        energy_ev=520,
+        n_epochs=10,
+        minibatch_size=8,
+        background_type='per_detector',
+        background_dataset_path='exchange/background',
+        optimize_background=True,
+        background_learning_rate=5e-3,
+        output_folder='recon_with_background'
+    )
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add configurable background handling to ptychography reconstruction, including per-detector, per-angle, and per-pattern modes
- propagate the background parameter through ptychography forward models and optimizer wiring so it can be refined during reconstruction
- provide a sample script that demonstrates enabling background refinement with measured detector data

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'adorym'; package is not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f442548c83209248deef7577a3e7